### PR TITLE
Improve docket entry API performance

### DIFF
--- a/cl/api/pagination.py
+++ b/cl/api/pagination.py
@@ -247,6 +247,26 @@ class MediumAdjustablePagination(VersionBasedPagination):
     page_size_query_param = "page_size"
 
 
+class LargePagePagination(VersionBasedPagination):
+    """Pagination that allows larger page sizes when plain text is excluded."""
+
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 250
+
+    def get_page_size(self, request: Request) -> int | None:  # type: ignore[override]
+        size = super().get_page_size(request)
+        if not size:
+            return size
+        include_plain = (
+            request.query_params.get("include_plain_text", "true").lower()
+            == "true"
+        )
+        if include_plain and size > 20:
+            return 20
+        return size
+
+
 class BigPagination(VersionBasedPagination):
     page_size = 300
 

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -134,6 +134,13 @@ class RECAPDocumentSerializer(
         exclude = ("docket_entry",)
 
 
+class RECAPDocumentLiteSerializer(RECAPDocumentSerializer):
+    """Serializer that omits the ``plain_text`` field."""
+
+    class Meta(RECAPDocumentSerializer.Meta):
+        exclude = RECAPDocumentSerializer.Meta.exclude + ("plain_text",)
+
+
 class DocketEntrySerializer(
     DynamicFieldsMixin, HyperlinkedModelSerializerWithId
 ):
@@ -148,6 +155,12 @@ class DocketEntrySerializer(
     class Meta:
         model = DocketEntry
         fields = "__all__"
+
+
+class DocketEntryLiteSerializer(DocketEntrySerializer):
+    """Serializer that uses :class:`RECAPDocumentLiteSerializer`."""
+
+    recap_documents = RECAPDocumentLiteSerializer(many=True, read_only=True)
 
 
 class FullDocketSerializer(DocketSerializer):


### PR DESCRIPTION
## Summary
- add `LargePagePagination` class
- add lite serializers for RECAP documents and docket entries
- allow excluding plain text on docket entry and document APIs

## Testing
- `ruff check cl/search/api_serializers.py cl/search/api_views.py cl/api/pagination.py`
- `ruff format cl/search/api_serializers.py cl/search/api_views.py cl/api/pagination.py`
- `./manage.py test cl.search.tests.test_pacer_bulk_fetch -v 1` *(fails: ModuleNotFoundError: No module named 'celery')*


------
https://chatgpt.com/codex/tasks/task_e_6850ae1314c083208b71b8e9af276e02